### PR TITLE
fixed documentation for the "keys-pressed" event

### DIFF
--- a/core-a11y-keys.html
+++ b/core-a11y-keys.html
@@ -74,6 +74,18 @@ Keys Syntax Grammar:
 @homepage github.io
 -->
 
+<!--
+Fired when a keycombo in `keys` is pressed.
+
+@event keys-pressed
+@param {Object} detail
+  @param {boolean} detail.shift true if shift key is pressed
+  @param {boolean} detail.ctrl true if ctrl key is pressed
+  @param {boolean} detail.meta true if meta key is pressed
+  @param {boolean} detail.alt true if alt key is pressed
+  @param {String} detail.key the normalized key
+-->
+
 <link rel="import" href="../polymer/polymer.html">
 
 <style shim-shadowdom>
@@ -258,11 +270,6 @@ Keys Syntax Grammar:
       return Boolean(a.alt) == Boolean(b.alt) && Boolean(a.ctrl) == Boolean(b.ctrl) && Boolean(a.shift) == Boolean(b.shift) && a.key === b.key;
     }
 
-    /**
-     * Fired when a keycombo in `keys` is pressed.
-     *
-     * @event keys-pressed
-     */
     function processKeys(ev) {
       var current = keyboardEventToKey(ev);
       for (var i = 0, dk; i < this._desiredKeys.length; i++) {


### PR DESCRIPTION
Params of the "keys-pressed" event are not specified in the [documentation ](https://www.polymer-project.org/0.5/docs/elements/core-a11y-keys.html#core-a11y-keys.events.keys-pressed). With this patch [context-free-parser](https://github.com/Polymer/context-free-parser) would include them to to output and then trey would appear in the documentation.